### PR TITLE
Add good_job migrations in preparation for upgrading to 2.xx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ruby '~> 3.2'
 # We need to use rails 6-1.stable to get around a problem with good_job:
 # https://github.com/bensheldon/good_job/issues/1016#issuecomment-1644915406
 gem 'rails', '~> 6.1', '>= 6.1.7.8'
-gem 'good_job', '~> 1.13'
+gem 'good_job', '~> 1.99'
 gem 'pg'
 gem 'httparty'
 gem 'federal_register', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     debug_inspector (1.1.0)
     diff-lcs (1.5.1)
     erubi (1.13.0)
-    et-orbi (1.2.7)
+    et-orbi (1.2.11)
       tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -100,8 +100,8 @@ GEM
       httparty (>= 0.14.0)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
-    fugit (1.9.0)
-      et-orbi (~> 1, >= 1.2.7)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -322,7 +322,7 @@ DEPENDENCIES
   csv
   factory_bot_rails (~> 6.4)
   federal_register (~> 0.7)
-  good_job (~> 1.13)
+  good_job (~> 1.99)
   httparty
   jbuilder (~> 2.12)
   kaminari (~> 1.2)

--- a/db/migrate/20240717224231_add_active_job_id_concurrency_key_cron_key_to_good_jobs.rb
+++ b/db/migrate/20240717224231_add_active_job_id_concurrency_key_cron_key_to_good_jobs.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class AddActiveJobIdConcurrencyKeyCronKeyToGoodJobs < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :active_job_id)
+      end
+    end
+
+    add_column :good_jobs, :active_job_id, :uuid
+    add_column :good_jobs, :concurrency_key, :text
+    add_column :good_jobs, :cron_key, :text
+  end
+end

--- a/db/migrate/20240717224232_add_active_job_id_index_and_concurrency_key_index_to_good_jobs.rb
+++ b/db/migrate/20240717224232_add_active_job_id_index_and_concurrency_key_index_to_good_jobs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class AddActiveJobIdIndexAndConcurrencyKeyIndexToGoodJobs < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  UPDATE_BATCH_SIZE = 1_000
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id_and_created_at)
+      end
+    end
+
+    add_index :good_jobs, [:active_job_id, :created_at], algorithm: :concurrently, name: :index_good_jobs_on_active_job_id_and_created_at
+    add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", algorithm: :concurrently, name: :index_good_jobs_on_concurrency_key_when_unfinished
+    add_index :good_jobs, [:cron_key, :created_at], algorithm: :concurrently, name: :index_good_jobs_on_cron_key_and_created_at
+
+    return unless defined? GoodJob::Job
+
+    reversible do |dir|
+      dir.up do
+        # Ensure that all `good_jobs` records have an active_job_id value
+        start_time = Time.current
+        loop do
+          break if GoodJob::Job.where(active_job_id: nil, finished_at: nil).where("created_at < ?", start_time).limit(UPDATE_BATCH_SIZE).update_all("active_job_id = (serialized_params->>'job_id')::uuid").zero?
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240717224233_add_retried_good_job_id_to_good_jobs.rb
+++ b/db/migrate/20240717224233_add_retried_good_job_id_to_good_jobs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddRetriedGoodJobIdToGoodJobs < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :retried_good_job_id)
+      end
+    end
+
+    add_column :good_jobs, :retried_good_job_id, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -117,7 +117,11 @@ CREATE TABLE public.good_jobs (
     finished_at timestamp without time zone,
     error text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    active_job_id uuid,
+    concurrency_key text,
+    cron_key text,
+    retried_good_job_id uuid
 );
 
 
@@ -327,6 +331,27 @@ CREATE INDEX index_agencies_sorns_on_agency_id ON public.agencies_sorns USING bt
 --
 
 CREATE INDEX index_agencies_sorns_on_sorn_id ON public.agencies_sorns USING btree (sorn_id);
+
+
+--
+-- Name: index_good_jobs_on_active_job_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_good_jobs_on_active_job_id_and_created_at ON public.good_jobs USING btree (active_job_id, created_at);
+
+
+--
+-- Name: index_good_jobs_on_concurrency_key_when_unfinished; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_good_jobs_on_concurrency_key_when_unfinished ON public.good_jobs USING btree (concurrency_key) WHERE (finished_at IS NULL);
+
+
+--
+-- Name: index_good_jobs_on_cron_key_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_good_jobs_on_cron_key_and_created_at ON public.good_jobs USING btree (cron_key, created_at);
 
 
 --
@@ -598,6 +623,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210129220248'),
 ('20210204202244'),
 ('20210303173553'),
-('20210303182701');
+('20210303182701'),
+('20240717224231'),
+('20240717224232'),
+('20240717224233');
 
 


### PR DESCRIPTION
Following [the good_job upgrade guide](https://github.com/bensheldon/good_job?tab=readme-ov-file#updating): We need these DB migrations to go out before we upgrade to good_job 2.xx. 