### PR TITLE
Update good_job to 2.99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ruby '~> 3.2'
 # We need to use rails 6-1.stable to get around a problem with good_job:
 # https://github.com/bensheldon/good_job/issues/1016#issuecomment-1644915406
 gem 'rails', '~> 6.1', '>= 6.1.7.8'
-gem 'good_job', '~> 1.99'
+gem 'good_job', '~> 2.99'
 gem 'pg'
 gem 'httparty'
 gem 'federal_register', '~> 0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,13 +105,14 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (1.99.1)
+    good_job (2.99.0)
       activejob (>= 5.2.0)
       activerecord (>= 5.2.0)
       concurrent-ruby (>= 1.0.2)
       fugit (>= 1.1)
       railties (>= 5.2.0)
       thor (>= 0.14.1)
+      webrick (>= 1.3)
       zeitwerk (>= 2.0)
     httparty (0.22.0)
       csv
@@ -301,6 +302,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -322,7 +324,7 @@ DEPENDENCIES
   csv
   factory_bot_rails (~> 6.4)
   federal_register (~> 0.7)
-  good_job (~> 1.99)
+  good_job (~> 2.99)
   httparty
   jbuilder (~> 2.12)
   kaminari (~> 1.2)

--- a/db/migrate/20240717225931_add_cron_at_to_good_jobs.rb
+++ b/db/migrate/20240717225931_add_cron_at_to_good_jobs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class AddCronAtToGoodJobs < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :cron_at)
+      end
+    end
+
+    add_column :good_jobs, :cron_at, :timestamp
+  end
+end

--- a/db/migrate/20240717225932_add_cron_key_cron_at_index_to_good_jobs.rb
+++ b/db/migrate/20240717225932_add_cron_key_cron_at_index_to_good_jobs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class AddCronKeyCronAtIndexToGoodJobs < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+      end
+    end
+
+    add_index :good_jobs,
+              [:cron_key, :cron_at],
+              algorithm: :concurrently,
+              name: :index_good_jobs_on_cron_key_and_cron_at,
+              unique: true
+  end
+end

--- a/db/migrate/20240717225933_create_good_job_processes.rb
+++ b/db/migrate/20240717225933_create_good_job_processes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateGoodJobProcesses < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.table_exists?(:good_job_processes)
+      end
+    end
+
+    create_table :good_job_processes, id: :uuid do |t|
+      t.timestamps
+      t.jsonb :state
+    end
+  end
+end

--- a/db/migrate/20240717225934_index_good_job_jobs_on_finished_at.rb
+++ b/db/migrate/20240717225934_index_good_job_jobs_on_finished_at.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class IndexGoodJobJobsOnFinishedAt < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+      end
+    end
+
+    add_index :good_jobs,
+              [:active_job_id],
+              name: :index_good_jobs_on_active_job_id,
+              algorithm: :concurrently
+
+    add_index :good_jobs,
+              [:finished_at],
+              where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL",
+              name: :index_good_jobs_jobs_on_finished_at,
+              algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -104,6 +104,18 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: good_job_processes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.good_job_processes (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    state jsonb
+);
+
+
+--
 -- Name: good_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -121,7 +133,8 @@ CREATE TABLE public.good_jobs (
     active_job_id uuid,
     concurrency_key text,
     cron_key text,
-    retried_good_job_id uuid
+    retried_good_job_id uuid,
+    cron_at timestamp without time zone
 );
 
 
@@ -282,6 +295,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 
 --
+-- Name: good_job_processes good_job_processes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.good_job_processes
+    ADD CONSTRAINT good_job_processes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: good_jobs good_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -334,6 +355,20 @@ CREATE INDEX index_agencies_sorns_on_sorn_id ON public.agencies_sorns USING btre
 
 
 --
+-- Name: index_good_jobs_jobs_on_finished_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_good_jobs_jobs_on_finished_at ON public.good_jobs USING btree (finished_at) WHERE ((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL));
+
+
+--
+-- Name: index_good_jobs_on_active_job_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_good_jobs_on_active_job_id ON public.good_jobs USING btree (active_job_id);
+
+
+--
 -- Name: index_good_jobs_on_active_job_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -352,6 +387,13 @@ CREATE INDEX index_good_jobs_on_concurrency_key_when_unfinished ON public.good_j
 --
 
 CREATE INDEX index_good_jobs_on_cron_key_and_created_at ON public.good_jobs USING btree (cron_key, created_at);
+
+
+--
+-- Name: index_good_jobs_on_cron_key_and_cron_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_good_jobs_on_cron_key_and_cron_at ON public.good_jobs USING btree (cron_key, cron_at);
 
 
 --
@@ -626,6 +668,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210303182701'),
 ('20240717224231'),
 ('20240717224232'),
-('20240717224233');
+('20240717224233'),
+('20240717225931'),
+('20240717225932'),
+('20240717225933'),
+('20240717225934');
 
 


### PR DESCRIPTION
Following [the good_job upgrade guide](https://github.com/bensheldon/good_job?tab=readme-ov-file#updating): Here we upgrade to good_job 2.xx (safe, because of the 1.99 migrations we just merged and deployed), and also run migrations that happened on the way to 2.99, before running 2.99.