### PR TITLE
Generate a new CSP nonce for every request

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,11 +17,9 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap and inline scripts
-  if Rails.env.test?
-    config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
-  else
-    config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  end
+  # This random-every-request generation is both more secure and will break Turbo+importmap (https://github.com/rails/rails/pull/43227)
+  # this will need to be revisited if we ever move away from jsbundling-rails/webpack and @rails/ujs
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w(script-src)
 
   # Report violations without enforcing the policy.


### PR DESCRIPTION
Bug:

Visiting the site for the very first time would generate a nonce for a nil session id, leading to an invalid value and being unable to run a search.

Fix:

Generate a random nonce for every environment.